### PR TITLE
Log 'nowplaying' track to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ colour, which means this allows transparency if your terminal supports it.
 be modified. Just open a new terminal session and your colours will
 be back to normal.
 
-### Now playing
+### Now Playing
 
 To log the currently playing track to a file, include a `nowplaying` section in
 your config file with `enable` set to `yes`. A `filename` may then be specified,
@@ -73,9 +73,11 @@ or the default value of `~/.nowplaying` will be used.
 This file may then be used in status bars or simple notifications systems. For
 example, here is a simple i3blocks definition:
 
-    [music]
-    command=cat ~/.nowplaying
-    interval=5
+```
+[music]
+command=cat ~/.nowplaying
+interval=5
+```
 
 ## Running Google Py Music
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ colour, which means this allows transparency if your terminal supports it.
 be modified. Just open a new terminal session and your colours will
 be back to normal.
 
+### Now playing
+
+To log the currently playing track to a file, include a `nowplaying` section in
+your config file with `enable` set to `yes`. A `filename` may then be specified,
+or the default value of `~/.nowplaying` will be used.
+
+This file may then be used in status bars or simple notifications systems. For
+example, here is a simple i3blocks definition:
+
+    [music]
+    command=cat ~/.nowplaying
+    interval=5
+
 ## Running Google Py Music
 
 Once installed and configured, the program can be run from the terminal

--- a/gpymusic/common.py
+++ b/gpymusic/common.py
@@ -2,6 +2,7 @@ from gmusicapi import Mobileclient
 # Imports are stupid.
 mc = Mobileclient()  # noqa Our interface to Google Play Music.
 
+from . import nowplaying
 from . import songqueue
 from . import view
 from . import writer
@@ -17,4 +18,5 @@ CONFIG_DIR = join(expanduser('~'), '.config', 'gpymusic')
 q = songqueue.Queue()  # Queue/playlist.
 w = writer.Writer(None, None, None, None, curses=False)  # Output handler.
 v = view.View()  # Main window contents.
+np = nowplaying.NowPlaying()
 client = None  # To be set in the main executable.

--- a/gpymusic/config/config.json
+++ b/gpymusic/config/config.json
@@ -11,5 +11,9 @@
         "highlight": "#abc123",
         "content1": "#abc123",
         "content2": "#abc123"
+    },
+    "nowplaying": {
+        "enable": "no",
+        "filename": "~/.nowplaying"
     }
 }

--- a/gpymusic/nowplaying.py
+++ b/gpymusic/nowplaying.py
@@ -1,0 +1,28 @@
+class NowPlaying():
+    def __init__(self):
+        self.enabled = False
+
+    def initialise(self, filename):
+        """
+        Initialise the nowplaying file with a filename.
+
+        Arguments:
+        filename: The full file path to the nowplaying file.
+        """
+        self.filename = filename
+        self.enabled = True
+
+    def close(self):
+        """Overwrite the nowplaying file with an empty file"""
+        if not self.enabled:
+            return
+        f = open(self.filename, 'w')
+        f.close()
+
+    def update(self, playing):
+        """Overwrite the nowplaying file with a string"""
+        if not self.enabled:
+            return
+        f = open(self.filename, 'w')
+        f.write(playing)
+        f.close()

--- a/gpymusic/start.py
+++ b/gpymusic/start.py
@@ -1,7 +1,7 @@
 from . import common
 
 from getpass import getpass
-from os.path import basename, exists, isfile, join
+from os.path import basename, exists, expanduser, isfile, join
 from time import sleep
 
 import curses as crs
@@ -31,6 +31,19 @@ def validate_config(config):
     # Check if there is enough user info.
     if not all([k in config['user'] for k in user_fields]):
         common.w.goodbye('Missing user info in config file: Exiting.')
+
+    if 'nowplaying' in config and 'enable' not in config['nowplaying']:
+        common.w.goodbye(
+            'Missing nowplaying enable flag in config file: Exiting.')
+    else:
+        nowplaying = config['nowplaying']['enable'] == 'yes'
+
+    if nowplaying:
+        if 'filename' in config['nowplaying']:
+            filename = config['nowplaying']['filename']
+        else:
+            filename = '~/.nowplaying'
+        common.np.initialise(expanduser(filename))
 
     # Check if there is any colour info.
     if 'colour' in config and 'enable' not in config['colour']:

--- a/gpymusic/writer.py
+++ b/gpymusic/writer.py
@@ -103,6 +103,7 @@ class Writer():
         """
         if self.test:
             return
+        common.np.update(string if string is not None else '')
         self.addstr(self.infobar, 'Now playing: %s' %
                     (string if string is not None else 'None'))
 
@@ -181,6 +182,7 @@ class Writer():
         try:
             string = self.inbar.getstr()
         except KeyboardInterrupt:
+            common.np.close()
             self.goodbye('Goodbye, thanks for using Google Py Music!')
 
         self.inbar.deleteln()
@@ -201,7 +203,7 @@ class Writer():
 
     def measure_fields(self, width):
         """
-        Determine max number of  characters and starting point
+        Determine max number of characters and starting point
           for category fields.
 
         Arguments:


### PR DESCRIPTION
I don't know if you're at all interested in merging this, but it's a feature I wanted (for displaying currently playing track in i3blocks) so I added it for myself.

When configured, the current track will be logged to a file, allowing the user the display the music status externally, e.g. as a status bar element or system notification.