### PR TITLE
Oauth support for free and paid users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ replace.sh
 dist/
 build/
 gpymusic.egg-info/
+*.pyc
+start

--- a/bin/gpymusic
+++ b/bin/gpymusic
@@ -6,14 +6,20 @@ from gpymusic import start
 
 if __name__ == '__main__':
     start.check_dirs()
+    config = start.read_config()
+    # why so early? curses window break the regular terminal input
+    # and we need it for oauth
+    if 'oauth' in config['user'] and config['user']['oauth']:
+        start.oauth_login(config['user'])
     common.w.replace_windows(*start.get_windows())
     common.w.curses = True
-    config = start.read_config()
     colour = start.validate_config(config)
     if colour:
         start.set_colours(config['colour'])
         common.w.colour = True
     common.w.welcome()
+
+    # This remains here to validate the user is logged in with the previous oauth method
     start.login(config['user'])
     common.w.addstr(
         common.w.infobar,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2017.4.17
 chardet==3.0.3
 decorator==4.0.11
 future==0.16.0
-gmusicapi==10.1.2
+gmusicapi==11.0.5-rc.1
 gpsoauth==0.4.1
 httplib2==0.10.3
 idna==2.5


### PR DESCRIPTION
Changes to add support for oauth to the player and avoid using username/password or app passwords.

In the last week [oauth login support was introduced](https://github.com/simon-weber/gmusicapi/issues/620#issuecomment-440797236) for the mobile client on gmusicapi which is the base lib for this client.

These changes are backwards compatible and should work with old versions of the library but if you want to use oauth you will need to uninstall the current gmusicapi and install the develop branch instead

`pip3 uninstall gmusicapi`
`pip3 install git+https://github.com/simon-weber/gmusicapi.git@develop#egg=gmusicapi`

To tell gpymusic that should login with oauth you should add `oauth: true` to the user section on the configuration file

```
    "user": {
        "email": "email@gmail.com",
        "deviceid": "DEVICE_ID",
        "oauth": true
    },
```

the password is not longer required and email also should not be required but I want to keep it for future functionalities.

On the first run with `oauth: true` You'll be prompted to open an url, allow permissions and copy the given token from the web interface to the terminal. If this process fails the program will finish and you'll have to start over.

Please test and let me know if this works for you.